### PR TITLE
Upgrade projects to .NET 9, align package versions, and bump client version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/AccountServer/bin/Debug/net8.0/AccountServer.dll",
+            "program": "${workspaceFolder}/AccountServer/bin/Debug/net9.0/AccountServer.dll",
             "args": [],
             "cwd": "${workspaceFolder}/AccountServer",
             "stopAtEntry": false,
@@ -35,7 +35,7 @@
             "request": "launch",
             "preLaunchTask": "build_testclient",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/AccountTestClient/bin/Debug/net8.0/AccountTestClient.dll",
+            "program": "${workspaceFolder}/AccountTestClient/bin/Debug/net9.0/AccountTestClient.dll",
             "args": [],
             "cwd": "${workspaceFolder}/AccountTestClient",
             "stopAtEntry": false,

--- a/AccountClient/AccountClient.csproj
+++ b/AccountClient/AccountClient.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
     <PackageReference Include="DarkFactor.Common.Lib" Version="1.6.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/AccountClient/AccountClient.nuspec
+++ b/AccountClient/AccountClient.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>DarkFactor.AccountClient.Lib</id>
-    <version>1.2.12</version>
+    <version>1.2.13</version>
     <authors>Thor Richard Hanssen</authors>
     <description>Package Description</description>
     <dependencies>

--- a/AccountClient/AccountClient.nuspec
+++ b/AccountClient/AccountClient.nuspec
@@ -6,12 +6,12 @@
     <authors>Thor Richard Hanssen</authors>
     <description>Package Description</description>
     <dependencies>
-      <group targetFramework="net8.0">
+      <group targetFramework="net9.0">
         <dependency id="DarkFactor.Common.Lib" version="1.6.6" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.EntityFrameworkCore" version="3.1.5" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore" version="9.0.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="Swashbuckle.AspNetCore.SwaggerGen" version="6.3.0" exclude="Build,Analyzers" />
-        <dependency id="Swashbuckle.AspNetCore.SwaggerUI" version="6.3.0" exclude="Build,Analyzers" />
+        <dependency id="Swashbuckle.AspNetCore.SwaggerGen" version="6.6.2" exclude="Build,Analyzers" />
+        <dependency id="Swashbuckle.AspNetCore.SwaggerUI" version="6.6.2" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/AccountCommon/AccountCommon.csproj
+++ b/AccountCommon/AccountCommon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/AccountServer/AccountServer.csproj
+++ b/AccountServer/AccountServer.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
     <PackageReference Include="DarkFactor.Common.Lib" Version="1.6.6" />
     <PackageReference Include="DarkFactor.MailClient.Lib" Version="1.1.1" />
   </ItemGroup>

--- a/AccountServer/Program.cs
+++ b/AccountServer/Program.cs
@@ -26,7 +26,7 @@ namespace AccountServer
     class Program
     {
         public static string AppName = "AccountServer";
-        public static string AppVersion = "1.2.12";
+        public static string AppVersion = "1.2.13";
 
         static void Main(string[] args)
         {

--- a/AccountTestClient/AccountTestClient.csproj
+++ b/AccountTestClient/AccountTestClient.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="DarkFactor.Common.Lib" Version="1.6.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use .Net Core 5 image
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+# Use .NET 9 SDK image
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build-env
 WORKDIR /app
 
 # Copy files
@@ -17,7 +17,7 @@ RUN --mount=type=secret,id=nuget_username \
 RUN dotnet publish AccountServer/AccountServer.csproj -c Release -o out 
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "AccountServer.dll"]


### PR DESCRIPTION
## Summary
- Upgrade all projects from net8.0 to net9.0
- Align package versions across AccountServer, AccountClient, AccountCommon, and AccountTestClient
- Update Docker SDK/runtime images to .NET 9
- Update VS Code launch targets to net9.0 outputs
- Bump AccountClient package/app version from 1.2.12 to 1.2.13

## Validation
- `dotnet build AccountServer/AccountServer.csproj` succeeded
- `dotnet build AccountTestClient/AccountTestClient.csproj` succeeded